### PR TITLE
Normalize all text files to LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf


### PR DESCRIPTION
This fix changes with blank diffs resulting from line ending being changed between LF and CRLF. 

These changes *may* appear one last time for edited files with CRLF after this PR is merged. I made sure to renormalize the entire repository, though.