### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,7 @@
-build
 build/
-build/*
 export_presets.cfg
-.import
 .import/
-.import/*
-.godot
 .godot/
-.godot/*
 *.translation
 .mono/
 addons/discord_game_sdk/bin

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ export_presets.cfg
 .godot/
 *.translation
 .mono/
-addons/discord_game_sdk/bin
-addons/discord_game_sdk/bin/
-addons/discord_game_sdk/bin/*
+addons/discord_game_sdk/discord_game_sdk.*
+addons/discord_game_sdk/libdiscord_game_sdk.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-build/
+build/**
+!build/.gdignore
 export_presets.cfg
 .import/
 .godot/


### PR DESCRIPTION
Ignoring a directory will also ignore everything inside it, so `dir/*` ignores are redundant. File ignores(the ones without a trailing slash) are also unnecessary for `build`, `.godot` and `.import` since they are always a directory.

I ignored everything *inside* `build` recursively and not `build` itself to keep the `.gdignore` file which will make Godot ignore the `build` directory.