### PR TITLE
Fix Note Visual Approach visible with Ghost enabled.

### DIFF
--- a/scripts/game/NoteManager.gd
+++ b/scripts/game/NoteManager.gd
@@ -146,7 +146,10 @@ func note_reposition(i:int):
 				at.origin.z = 0
 			
 			$ASq.multimesh.set_instance_transform(i - current_note, at)
-			$ASq.multimesh.set_instance_color(i - current_note, Color(1,1,1,pow(linstep(Rhythia.get("spawn_distance"),0,current_dist),1.7)))
+			if Rhythia.mod_ghost:
+				$ASq.multimesh.set_instance_color(i - current_note, Color(1,1,1,1 * alpha))
+			else:
+				$ASq.multimesh.set_instance_color(i - current_note, Color(1,1,1,pow(linstep(Rhythia.get("spawn_distance"),0,current_dist),1.7)))
 		
 #		$Label.text += "(%.02f: %s -> %s = %s) %s\n" % [current_dist,fade_in_start,fade_in_end,fade_in,alpha]
 		


### PR DESCRIPTION
# References
NVA -> Note Visual Approach

# Changes
Basil's calculations of NVA are weird, and it doesn't calculate the alpha, so, with Ghost enabled, NVA would be visible even if ghost was on.
My (dumb) change fixes this... with 3 lines...
*I shit you not, read the commit log*

# Demos

## NVA on Current Build:

https://github.com/krmeet/sound-space-plus/assets/57727007/d01b492a-06c8-4c08-a6f6-32b59bac6aed

## NVA on a Built build with the code included in this commit:

https://github.com/krmeet/sound-space-plus/assets/57727007/fbbeccc9-b0e3-42d2-828c-cf02aa41aee1

