### PR TITLE
Fix ability to enable Alt Camera during Gameplay

### DIFF
--- a/scripts/game/cam_handler.gd
+++ b/scripts/game/cam_handler.gd
@@ -1,6 +1,7 @@
 extends Spatial
 
 var state = (Rhythia.replaying and Rhythia.alt_cam)
+var debug:bool = OS.has_feature("debug")
 
 func _ready():
 	PhysicsServer.set_active(!Rhythia.visual_mode and (Rhythia.get("cam_unlock") or Rhythia.vr))
@@ -29,7 +30,7 @@ func _ready():
 		$Game/Avatar/Head/Accessories/CubellaHair.visible = true
 
 func _process(delta):
-	if Input.is_action_just_pressed("debug_freecam_toggle"):
+	if Input.is_action_just_pressed("debug_freecam_toggle") and debug: # Should only be enabled in Debug/Developer mode
 		state = !state
 		_ready()
 	if Input.is_action_just_pressed("retry"):


### PR DESCRIPTION
Literally added a checker if Debug mode was active or not lol
Basically the lack of this checker enabled everyone to use the alt cam (conveniently labeled "debug_freecam_toggle") during gameplay as it invalidated the state variable.

(Prevents fake spin passes as you could use this to play camlock on Spin)

Demo by @anthony-63 can be found [here](https://cdn.discordapp.com/attachments/1071847668462133351/1164134467103891497/2023-09-16_09-51-21.mov)