### PR TITLE
fix replay song ids and note opacity

### DIFF
--- a/scripts/content/game/Replay.gd
+++ b/scripts/content/game/Replay.gd
@@ -96,7 +96,7 @@ func read_data(from_path:String=""):
 			debug_txt.reserved_1 = file.get_64()
 			if sv >= 4: debug_txt.replay_hwid = file.get_line()
 			id = file.get_line()
-			var song_id = id.split(".")[0]
+			var song_id = id.substr(0, id.find_last(".")).substr(0, id.find_last("."))
 			var fsong = Rhythia.registry_song.get_item(song_id)
 			
 			debug_txt.replay_id = id

--- a/scripts/game/NoteManager.gd
+++ b/scripts/game/NoteManager.gd
@@ -139,11 +139,11 @@ func note_reposition(i:int):
 		if fade_in_enabled or fade_out_enabled:
 			
 			if fade_in_enabled: 
-				fade_in = pow(linstep(fade_in_start,fade_in_end,current_dist), 1.3)
+				fade_in = (pow(linstep(fade_in_start,fade_in_end,current_dist), 1.3)) * Rhythia.note_opacity
 			if fade_out_enabled:
-				fade_out = (1 - fade_out_base) + (pow(linstep(fade_out_end,fade_out_start,current_dist), 1.3) * fade_out_base)
+				fade_out = ((1 - fade_out_base) + (pow(linstep(fade_out_end,fade_out_start,current_dist), 1.3) * fade_out_base)) * Rhythia.note_opacity
 			
-			alpha = min(fade_in,fade_out)
+			alpha = min(min(fade_in,fade_out), alpha)
 		
 		
 		$Notes.multimesh.set_instance_transform(i - current_note, nt)

--- a/scripts/game/NoteManager.gd
+++ b/scripts/game/NoteManager.gd
@@ -143,7 +143,7 @@ func note_reposition(i:int):
 			if fade_out_enabled:
 				fade_out = ((1 - fade_out_base) + (pow(linstep(fade_out_end,fade_out_start,current_dist), 1.3) * fade_out_base)) * Rhythia.note_opacity
 			
-			alpha = min(min(fade_in,fade_out), alpha)
+			alpha = min(fade_in,fade_out)
 		
 		
 		$Notes.multimesh.set_instance_transform(i - current_note, nt)


### PR DESCRIPTION
this fixes problems caused by periods (".") in the song id when opening a replay
example of issue: https://discord.com/channels/1064060807320702996/1228040695403642913